### PR TITLE
Bugfix: general icons overriden by social set

### DIFF
--- a/app/assets/stylesheets/social_foundicons_ie7.scss
+++ b/app/assets/stylesheets/social_foundicons_ie7.scss
@@ -1,7 +1,7 @@
 @import "social_settings";
 
 /* general icons for IE7 */
-[class*="#{$classPrefix}"] {
+[class*="social #{$classPrefix}"] {
   font-family: $fontName;
   font-weight: normal;
   font-style: normal;


### PR DESCRIPTION
Just a missing `social` class declaration in the ie7 stylesheet.
