### PR TITLE
Remove dependencies for easier sass upgrade

### DIFF
--- a/foundation-icons-sass-rails.gemspec
+++ b/foundation-icons-sass-rails.gemspec
@@ -18,6 +18,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'railties', '>= 3.1.1'
-  s.add_runtime_dependency 'sass-rails', '>= 3.1.1'
+  s.add_runtime_dependency 'sass-rails'
 end


### PR DESCRIPTION
Due to dependency of `sass-rails` and presence of `railties` it's currently not possible to upgrade sass in a Rails project. Removing these dependencies does not seem to do any harm and makes upgrading possible.
